### PR TITLE
[fix] tagの更新

### DIFF
--- a/app/views/public/posts/_posts.html.erb
+++ b/app/views/public/posts/_posts.html.erb
@@ -37,22 +37,19 @@
 
           <!--カードボディ-->
           <div class="card-body pb-0 pt-1" style="padding-left: 0.5rem;">
-            <!-- 釣り方 -->
-            <% if post.rigs.present? %>
-              <p class="card-text" style="font-size: 0.9rem;">
-                <% post.rigs.first(3).each do |rig| %>
-                  <span style="color: #4d992f;">＃</span><%= link_to rig.name, posts_path(rig_id: rig), class: "text-dark" %>
-                <% end %>
-                <!--釣り方の表示数の指定-->
-                <% if post.rigs.count > 4 %>
-                  <span>...</span>
-                <% end %>
-              </p>
-            <% else %>
-              <!-- rigsがない場合、同じサイズの余白を表示 -->
-              <div style="min-height: 22px;"></div>
-            <% end %>
-          </div>
+  <!-- 釣り方 -->
+  <% if post.rigs.present? %>
+    <p class="card-text" style="font-size: 0.9rem;">
+      <% post.rigs.each do |rig| %>
+        <span style="color: #4d992f;">＃</span><%= link_to rig.name, posts_path(rig_id: rig), class: "text-dark" %>
+      <% end %>
+    </p>
+  <% else %>
+    <!-- rigsがない場合、同じサイズの余白を表示 -->
+    <div style="min-height: 22px;"></div>
+  <% end %>
+</div>
+
 
           <!--魚の画像-->
           <div class="my-3">

--- a/app/views/public/posts/show.html.erb
+++ b/app/views/public/posts/show.html.erb
@@ -60,17 +60,10 @@
         <!--釣り方の有無の条件分岐-->
         <% if @post.rigs.present? %>
           <p class="card-text" style="font-size: 1.0rem;">
-            <% @post.rigs.first(3).each do |rig| %>
+            <% @post.rigs.each do |rig| %>
               <span style="color: #4d992f;">＃</span><%= link_to rig.name, posts_path(rig_id: rig), class: "text-dark" %>
             <% end %>
-            <!--釣り方の表示数の指定-->
-            <% if @post.rigs.count > 4 %>
-              <span>...</span>
-            <% end %>
           </p>
-        <% else %>
-          <!-- rigsがない場合、同じサイズの余白を表示 -->
-          <div style="min-height: 22px;"></div>
         <% end %>
 
         <!-- 画像 -->


### PR DESCRIPTION
完成したPFの動作チェックをしていたところ、投稿の編集画面で編集したタグが投稿一覧に反映されないことに気がつきました。再度、編集画面を開くと編集したタグがフォームに残っています。

例えば、釣り方（タグ）が「夜釣り　泳がせ」の投稿があった場合に、投稿の編集画面で「夜釣り　泳がせ釣り」と編集して更新すると、投稿一覧の釣り方（タグ）には「夜釣り」のみ表示されています。しかし、編集画面を再度開くと「夜釣り　泳がせ釣り」と表示されています。

これは編集後のタグが適切にDBに保存されていないために生じた不具合なのか、コントローラーやビューに問題があるのかわかりません。

追記
タグが2個のとき、上記の不具合は生じませんでした。3個以上のタグが登録されている場合に、起きる不具合のようです。

タグが2個のとき、投稿の編集画面でタグを１つ追加します。
3個になったタグを、投稿の編集画面で更新すると、上記の不具合が生じません。

なので、今回の不具合は新規投稿時に3個以上のタグを登録した投稿に生じるようです。

そこで、タグの表示を３つに制限する記述を削除してタグを全て表示できるようにすると不具合はなくなりました。

<div class="card-body pb-0 pt-1" style="padding-left: 0.5rem;">
            <!-- 釣り方 -->
            <% if post.rigs.present? %>
              <p class="card-text" style="font-size: 0.9rem;">
                <% post.rigs.first(3).each do |rig| %>
                  <span style="color: #4d992f;">＃</span><%= link_to rig.name, posts_path(rig_id: rig), class: "text-dark" %>
                <% end %>
                <!--釣り方の表示数の指定-->
                <% if post.rigs.count > 4 %>
                  <span>...</span>
                <% end %>
              </p>
            <% else %>
              <!-- rigsがない場合、同じサイズの余白を表示 -->
              <div style="min-height: 22px;"></div>
            <% end %>
          </div>